### PR TITLE
Add binary_relocation to fix a segfault caused by patchelf

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx or ppc64le]
   binary_relocation: false
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ source:
 build:
   number: 2
   skip: true  # [osx or ppc64le]
-  binary_relocation: false
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ source:
 build:
   number: 1
   skip: true  # [osx or ppc64le]
+  binary_relocation: false
 
 requirements:
   build:
@@ -31,7 +32,8 @@ requirements:
 
 outputs:
   - name: cuda-tileiras
-    build:                           # [win]
+    build:
+      binary_relocation: false
       script:                        # [win]
          - move bin\* %LIBRARY_BIN%  # [win]
     files:             # [linux]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Hello, this is Onur from Anaconda Package Build Team.

We have encountered a segmentation fault during the testing of `tileiras` binary executable on our internal systems. For some reason, we observe this issue on `linux-64` builds only. We think `patchelf` is breaking something on `tileiras` executable. Unfortunately, we were unable to replicate on containerized environments. On the other hand, we were able to identify the source of the issue and provide a fix.

The error we see during the test stage

```
+ tileiras --version
/home/XXX/croot/cuda-tileiras_1769051028897/test_tmp/run_test.sh: line 8:  2965 Segmentation fault      tileiras --version
```

When we look at the `dmesg` outputs, we see the following logs

```
[Fri Jan 23 01:58:04 2026] 2471 (tileiras): Uhuuh, elf segment at 0000000000402000 requested but the memory is mapped already
```

During the build stage, we see the warning below

```
WARNING :: get_rpaths_raw()=[] and patchelf=[''] disagree for /home/XXX/croot/cuda-tileiras-split_1769231039352/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/bin/tileiras
```

and it is possible to observe `tileiras` application's SHA256 hash change after the `patchelf` stage during the build.

```
# Hash check on 'tileiras` directly downloaded from Nvidia servers
f0eb415767f403c96cbabf0817c3bcf70a50f88dfc8845fe36ebe21635fa6707

# Hash check on `tileiras' after package build
681d6c5a50089f874296723936dfa46723746d27f0a603bd3468e8dee2648d33
```

After adding `binary_relocation` to the recipe, the SHA256 hash of the packaged `tileiras` would become the same as the directly downloaded one

```
# Hash check after adding 'binary_relocation'
f0eb415767f403c96cbabf0817c3bcf70a50f88dfc8845fe36ebe21635fa6707
```

and the tests would pass successfully

```
+ tileiras --version
tileiras: NVIDIA (R) Cuda Tile IR optimizing assembler
Copyright (c) 2005-2025 NVIDIA Corporation
Built on Fri_Nov__7_19:49:56_PST_2025
Cuda compilation tools, release 13.1, V13.1.80
Build local.local.36836380_
```

<!--
Please add any other relevant info below:
-->

We have observed that some of the CUDA feedstocks has already implemented `binary_relocation` with similar reasons; i.e. `patchelf` breaking the binary.

As requested by the team, I am cc'ing @cbouss and @billysuh7.
