### PR TITLE
Replace cuda-nvcc with cuda-nvcc-tools and cuda-nvvm-impl

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   skip: true  # [osx or ppc64le]
   binary_relocation: false
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ source:
 build:
   number: 2
   skip: true  # [osx or ppc64le]
-  binary_relocation: false
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ source:
 build:
   number: 1
   skip: true  # [osx or ppc64le]
+  binary_relocation: false
 
 requirements:
   build:
@@ -31,7 +32,8 @@ requirements:
 
 outputs:
   - name: cuda-tileiras
-    build:                           # [win]
+    build:
+      binary_relocation: false
       script:                        # [win]
          - move bin\* %LIBRARY_BIN%  # [win]
     files:             # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 2
+  number: 3
   skip: true  # [osx or ppc64le]
 
 requirements:
@@ -46,7 +46,8 @@ outputs:
         - cuda-version {{ cuda_version }}
       run:
         - {{ pin_compatible("cuda-version", max_pin="x.x") }}
-        - cuda-nvcc
+        - cuda-nvcc-tools
+        - cuda-nvvm-impl
     test:
       commands:
         - test -f $PREFIX/bin/tileiras                    # [linux]


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<!-- -->conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Fixes #5

Replace `cuda-nvcc` runtime dependency with `cuda-nvcc-tools` and `cuda-nvvm-impl`. The `tileiras` tool only needs `ptxas` (from `cuda-nvcc-tools`) and `libnvvm` (from `cuda-nvvm-impl`), not the full `cuda-nvcc` package which pulls in `gcc`/`gxx` on Linux. This reduces the installation footprint.

Closes #4